### PR TITLE
allowing some deployments to be scaled according to other deployments' pod numbers

### DIFF
--- a/autoscale.py
+++ b/autoscale.py
@@ -78,6 +78,7 @@ if __name__ == '__main__':
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,
         scaling_config=os.getenv('AUTOSCALING'),
+        secondary_scaling_config=os.getenv('SECONDARY_AUTOSCALING'),
         backoff_seconds=os.getenv('REDIS_INTERVAL', '1'))
 
     INTERVAL = int(os.getenv('INTERVAL', '5'))

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -208,19 +208,19 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
         return int(current_pods)
 
     def get_desired_pods(self, deployment, key, keys_per_pod, min_pods,
-            max_pods, current_pods):
+                         max_pods, current_pods):
         autoscaled_deployments = {
-                'redis-consumer-deployment':7,
-                'zip-consumer-deployment':1,
-                'data-processing-deployment':1}
+            'redis-consumer-deployment': 7,
+            'zip-consumer-deployment': 1,
+            'data-processing-deployment': 1}
 
         if deployment in autoscaled_deployments:
             tf_serving_pods = self.get_current_pods(
-                    'deepcell','deployment','tf-serving-deployment')
+                'deepcell', 'deployment', 'tf-serving-deployment')
             new_tf_serving_pods = tf_serving_pods - self.tf_serving_pods
             self.tf_serving_pods = tf_serving_pods
             extra_pods = new_tf_serving_pods * \
-                    autoscaled_deployments[deployment]
+                autoscaled_deployments[deployment]
             desired_pods = current_pods + extra_pods
         else:
             desired_pods = self.redis_keys[key] // keys_per_pod

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -179,8 +179,8 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
             raise ValueError('The resource_type of {} is unsuitable. Use either'
                              '`deployment` or `job`'.format(resource_type))
 
-        deployment_re = r'Replicas:\s+([0-9]+) desired | [0-9]+ updated | ' + \
-                        r'[0-9]+ total | ([0-9]+) available | [0-9]+ unavailable'
+        deployment_re = r'Replicas:\s+([0-9]+) desired \| [0-9]+ updated \| ' + \
+                        r'[0-9]+ total \| ([0-9]+) available \| [0-9]+ unavailable'
 
         description = self._get_kubectl_output([
             'kubectl', '-n', namespace, 'describe', resource_type, deployment

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -210,8 +210,8 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
     def get_desired_pods(self, deployment, key, keys_per_pod, min_pods,
             max_pods, current_pods):
         autoscaled_deployments = {
-                'redis-consumer-deployment':7
-                'zip-consumer-deployment':1
+                'redis-consumer-deployment':7,
+                'zip-consumer-deployment':1,
                 'data-processing-deployment':1}
 
         if deployment in autoscaled_deployments:

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -97,9 +97,8 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
                              'different. Got "{}" and "{}".'.format(
                                  deployment_delim, param_delim))
 
-        secondary_autoscaling_params = \
-                [x.split(param_delim) for x in
-                        secondary_scaling_config.split(deployment_delim)]
+        secondary_autoscaling_params = [x.split(param_delim) for x in
+                                        secondary_scaling_config.split(deployment_delim)]
         autoscaled_deployments = {}
         if len(secondary_autoscaling_params) > 1:
             for secondary_autoscaling in secondary_autoscaling_params:

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -90,19 +90,19 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
                 for x in scaling_config.split(deployment_delim)]
 
     def _get_secondary_autoscaling_params(self, secondary_scaling_config,
-                                deployment_delim=';',
-                                param_delim='|'):
+                                          deployment_delim=';',
+                                          param_delim='|'):
         if deployment_delim == param_delim:
             raise ValueError('`deployment_delim` and `param_delim` must be '
                              'different. Got "{}" and "{}".'.format(
                                  deployment_delim, param_delim))
 
         secondary_autoscaling_params = [x.split(param_delim)
-                for x in secondary_scaling_config.split(deployment_delim)]
+                    for x in secondary_scaling_config.split(deployment_delim)]
         autoscaled_deployments = {}
         for secondary_autoscaling in secondary_autoscaling_params:
-            autoscaled_deployments[ secondary_autoscaling[0] ] = \
-                    secondary_autoscaling[1]
+            autoscaled_deployments[secondary_autoscaling[0]] = \
+                secondary_autoscaling[1]
         return autoscaled_deployments
 
     def _make_kubectl_call(self, args):

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -61,7 +61,7 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
             param_delim=param_delim)
 
         self.autoscaled_deployments = self._get_secondary_autoscaling_params(
-            scaling_config=secondary_scaling_config.rstrip(),
+            secondary_scaling_config=secondary_scaling_config.rstrip(),
             deployment_delim=deployment_delim,
             param_delim=param_delim)
 
@@ -100,9 +100,10 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
         secondary_autoscaling_params = [x.split(param_delim)
                     for x in secondary_scaling_config.split(deployment_delim)]
         autoscaled_deployments = {}
-        for secondary_autoscaling in secondary_autoscaling_params:
-            autoscaled_deployments[secondary_autoscaling[0]] = \
-                secondary_autoscaling[1]
+        if len(secondary_autoscaling_params) > 1:
+            for secondary_autoscaling in secondary_autoscaling_params:
+                autoscaled_deployments[secondary_autoscaling[0]] = \
+                    secondary_autoscaling[1]
         return autoscaled_deployments
 
     def _make_kubectl_call(self, args):

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -97,8 +97,9 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
                              'different. Got "{}" and "{}".'.format(
                                  deployment_delim, param_delim))
 
-        secondary_autoscaling_params = [x.split(param_delim)
-                    for x in secondary_scaling_config.split(deployment_delim)]
+        secondary_autoscaling_params = \
+                [x.split(param_delim) for x in
+                        secondary_scaling_config.split(deployment_delim)]
         autoscaled_deployments = {}
         if len(secondary_autoscaling_params) > 1:
             for secondary_autoscaling in secondary_autoscaling_params:

--- a/autoscaler/autoscaler_test.py
+++ b/autoscaler/autoscaler_test.py
@@ -104,7 +104,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
 
     def test_hget(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
                                        backoff_seconds=0.01)
         data = scaler.hget('rhash_new', 'status')
         assert data == 'new'
@@ -113,7 +113,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
     def test_scan_iter(self):
         prefix = 'predict'
         redis_client = DummyRedis(fail_tolerance=2, prefix=prefix)
-        scaler = autoscaler.Autoscaler(redis_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
                                        backoff_seconds=0.01)
         data = scaler.scan_iter(match=prefix)
         keys = [k for k in data]
@@ -124,7 +124,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
     def test_get_desired_pods(self):
         # key, keys_per_pod, min_pods, max_pods, current_pods
         redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
                                        backoff_seconds=0.01)
         scaler.redis_keys['predict'] = 10
         # desired_pods is > max_pods
@@ -146,7 +146,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
 
     def test_get_current_pods(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
                                        backoff_seconds=0.01)
 
         # test invalid resource_type
@@ -171,7 +171,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
 
     def test_tally_keys(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
                                        backoff_seconds=0.01)
         scaler.tally_keys()
         assert scaler.redis_keys == {'predict': 2, 'train': 2}
@@ -189,14 +189,14 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         # non-integer values will warn, but not raise (or autoscale)
         bad_params = ['f0', 'f1', 'f3', 'ns', 'job', 'train', 'name']
         p = deployment_delim.join([param_delim.join(bad_params)])
-        scaler = autoscaler.Autoscaler(redis_client, p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, p, 'None', 0,
                                        deployment_delim, param_delim)
         scaler.scale_deployments()
 
         # not enough params will warn, but not raise (or autoscale)
         bad_params = ['0', '1', '3', 'ns', 'job', 'train']
         p = deployment_delim.join([param_delim.join(bad_params)])
-        scaler = autoscaler.Autoscaler(redis_client, p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, p, 'None', 0,
                                        deployment_delim, param_delim)
         scaler.scale_deployments()
 
@@ -204,7 +204,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         with pytest.raises(ValueError):
             bad_params = ['0', '1', '3', 'ns', 'bad_type', 'train', 'name']
             p = deployment_delim.join([param_delim.join(bad_params)])
-            scaler = autoscaler.Autoscaler(redis_client, p, 0,
+            scaler = autoscaler.Autoscaler(redis_client, p, 'None', 0,
                                            deployment_delim, param_delim)
             scaler.scale_deployments()
 
@@ -214,7 +214,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         params = [deploy_params, job_params]
         p = deployment_delim.join([param_delim.join(p) for p in params])
 
-        scaler = autoscaler.Autoscaler(redis_client, p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, p, 'None', 0,
                                        deployment_delim,
                                        param_delim)
         deploy_example = 'other\ntext\nReplicas:  4 desired | 2 updated | ' + \

--- a/autoscaler/autoscaler_test.py
+++ b/autoscaler/autoscaler_test.py
@@ -129,19 +129,19 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         scaler.redis_keys['predict'] = 10
         # desired_pods is > max_pods
         desired_pods = scaler.get_desired_pods(
-            'tf-serving-deployment','predict', 2, 0, 2, 1)
+            'tf-serving-deployment', 'predict', 2, 0, 2, 1)
         assert desired_pods == 2
         # desired_pods is < min_pods
         desired_pods = scaler.get_desired_pods(
-            'tf-serving-deployment','predict', 5, 9, 10, 0)
+            'tf-serving-deployment', 'predict', 5, 9, 10, 0)
         assert desired_pods == 9
         # desired_pods is in range
         desired_pods = scaler.get_desired_pods(
-            'tf-serving-deployment','predict', 3, 0, 5, 1)
+            'tf-serving-deployment', 'predict', 3, 0, 5, 1)
         assert desired_pods == 3
         # desired_pods is in range, current_pods exist
         desired_pods = scaler.get_desired_pods(
-            'tf-serving-deployment','predict', 10, 0, 5, 3)
+            'tf-serving-deployment', 'predict', 10, 0, 5, 3)
         assert desired_pods == 3
 
     def test_get_current_pods(self):

--- a/autoscaler/autoscaler_test.py
+++ b/autoscaler/autoscaler_test.py
@@ -128,16 +128,20 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
                                        backoff_seconds=0.01)
         scaler.redis_keys['predict'] = 10
         # desired_pods is > max_pods
-        desired_pods = scaler.get_desired_pods('predict', 2, 0, 2, 1)
+        desired_pods = scaler.get_desired_pods(
+            'tf-serving-deployment','predict', 2, 0, 2, 1)
         assert desired_pods == 2
         # desired_pods is < min_pods
-        desired_pods = scaler.get_desired_pods('predict', 5, 9, 10, 0)
+        desired_pods = scaler.get_desired_pods(
+            'tf-serving-deployment','predict', 5, 9, 10, 0)
         assert desired_pods == 9
         # desired_pods is in range
-        desired_pods = scaler.get_desired_pods('predict', 3, 0, 5, 1)
+        desired_pods = scaler.get_desired_pods(
+            'tf-serving-deployment','predict', 3, 0, 5, 1)
         assert desired_pods == 3
         # desired_pods is in range, current_pods exist
-        desired_pods = scaler.get_desired_pods('predict', 10, 0, 5, 3)
+        desired_pods = scaler.get_desired_pods(
+            'tf-serving-deployment','predict', 10, 0, 5, 3)
         assert desired_pods == 3
 
     def test_get_current_pods(self):


### PR DESCRIPTION
Bad programming practices abound for now, but this branch is intended to speed up horizontal pod autoscaling, which, unfortunately, ramps up unnecessarily slowly in Kubernetes 1.12.

The `get_desired_pods` method is essentially forked to scale some deployments to be scaled according to other deployments' pod numbers. This logic includes some hard-coded values that need to be replaced by general logic. This would probably be a good time to entirely rethink the structure of the convoluted AUTOSACALING environmental variable we pass in.