### PR TITLE
Replace subprocess with Kubernetes client

### DIFF
--- a/autoscale.py
+++ b/autoscale.py
@@ -62,6 +62,7 @@ def initialize_logger(debug_mode=True):
 
     logger.addHandler(console)
     logger.addHandler(fh)
+    logging.getLogger('kubernetes.client.rest').setLevel(logging.INFO)
 
 
 if __name__ == '__main__':

--- a/autoscale.py
+++ b/autoscale.py
@@ -38,6 +38,7 @@ import time
 import sys
 
 import redis
+import kubernetes
 
 import autoscaler
 
@@ -55,10 +56,9 @@ def initialize_logger(debug_mode=True):
 
     if debug_mode:
         console.setLevel(logging.DEBUG)
-        fh.setLevel(logging.DEBUG)
     else:
         console.setLevel(logging.INFO)
-        fh.setLevel(logging.INFO)
+    fh.setLevel(logging.DEBUG)
 
     logger.addHandler(console)
     logger.addHandler(fh)
@@ -75,8 +75,14 @@ if __name__ == '__main__':
         decode_responses=True,
         charset='utf-8')
 
+    kubernetes.config.load_incluster_config()
+
+    KUBE_CLIENT = kubernetes.client.CoreV1Api(
+        kubernetes.client.ApiClient())
+
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,
+        kube_client=KUBE_CLIENT,
         scaling_config=os.getenv('AUTOSCALING'),
         backoff_seconds=os.getenv('REDIS_INTERVAL', '1'))
 

--- a/autoscale.py
+++ b/autoscale.py
@@ -77,8 +77,7 @@ if __name__ == '__main__':
 
     kubernetes.config.load_incluster_config()
 
-    KUBE_CLIENT = kubernetes.client.CoreV1Api(
-        kubernetes.client.ApiClient())
+    KUBE_CLIENT = kubernetes.client.AppsV1Api()
 
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,

--- a/autoscale.py
+++ b/autoscale.py
@@ -38,7 +38,6 @@ import time
 import sys
 
 import redis
-import kubernetes
 
 import autoscaler
 
@@ -76,13 +75,8 @@ if __name__ == '__main__':
         decode_responses=True,
         charset='utf-8')
 
-    kubernetes.config.load_incluster_config()
-
-    KUBE_CLIENT = kubernetes.client.AppsV1Api()
-
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,
-        kube_client=KUBE_CLIENT,
         scaling_config=os.getenv('AUTOSCALING'),
         backoff_seconds=os.getenv('REDIS_INTERVAL', '1'))
 

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -42,7 +42,6 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
 
     Args:
         redis_client: Redis Client Connection object.
-        kube_client: Kubernetes Python Client object.
         scaling_config: string, joined lists of autoscaling configurations
         backoff_seconds: int, after a redis/subprocess error, sleep for this
             many seconds and retry the command.

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -203,7 +203,7 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
             jobs = self.list_namespaced_job(namespace)
             for j in jobs:
                 if j.metadata.name == deployment:
-                    current_pods = j.spec.completions  # TODO: is this right?
+                    current_pods = j.spec.parallelism  # TODO: is this right?
                     break
 
         return int(current_pods)
@@ -245,7 +245,6 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
             current_pods = self.get_current_pods(
                 namespace, resource_type, deployment)
 
-            # compute desired pods for this deployment
             desired_pods = self.get_desired_pods(
                 predict_or_train, keys_per_pod,
                 min_pods, max_pods, current_pods)
@@ -260,8 +259,8 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
 
             if resource_type == 'job':
                 # TODO: Find a suitable method for scaling jobs
-                body = {'spec': {'completions': desired_pods}}
                 res = self.patch_namespaced_job(deployment, namespace, body)
+                body = {'spec': {'parallelism': desired_pods}}
 
             elif resource_type == 'deployment':
                 body = {'spec': {'replicas': desired_pods}}

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -50,8 +50,8 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
         param_delim: string, character delimiting deployment config parameters.
     """
 
-    def __init__(self, redis_client, scaling_config,
-                 backoff_seconds=1, deployment_delim=';', param_delim='|'):
+    def __init__(self, redis_client, scaling_config, backoff_seconds=1,
+                 deployment_delim=';', param_delim='|'):
         self.redis_client = redis_client
         self.backoff_seconds = int(backoff_seconds)
         self.logger = logging.getLogger(str(self.__class__.__name__))

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -23,6 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
+"""Autoscaler class"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/autoscaler/autoscaler_test.py
+++ b/autoscaler/autoscaler_test.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
 import redis
 import pytest
 
@@ -149,7 +148,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         keys = [k for k in data]
         expected = [k for k in redis_client.keys() if k.startswith(prefix)]
         assert scaler.redis_client.fail_count == redis_client.fail_tolerance
-        np.testing.assert_array_equal(keys, expected)
+        assert keys == expected
 
     def test_get_desired_pods(self):
         # key, keys_per_pod, min_pods, max_pods, current_pods

--- a/autoscaler/autoscaler_test.py
+++ b/autoscaler/autoscaler_test.py
@@ -28,8 +28,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import redis
 import pytest
+import redis
+import kubernetes
 
 import autoscaler
 
@@ -106,24 +107,37 @@ class DummyRedis(object):  # pylint: disable=useless-object-inheritance
 
 class DummyKubernetes(object):
 
+    def __init__(self, fail=False):
+        self.fail = fail
+
     def list_namespaced_deployment(self, *args, **kwargs):
+        if self.fail:
+            raise kubernetes.client.rest.ApiException('thrown on purpose')
         return Bunch(items=[
             Bunch(spec=Bunch(replicas='4'), metadata=Bunch(name='pod1')),
             Bunch(spec=Bunch(replicas='8'), metadata=Bunch(name='pod2'))
         ])
 
     def list_namespaced_job(self, *args, **kwargs):
+        if self.fail:
+            raise kubernetes.client.rest.ApiException('thrown on purpose')
         return Bunch(items=[
-            Bunch(spec=Bunch(completions='1'), metadata=Bunch(name='pod1')),
-            Bunch(spec=Bunch(completions='2'), metadata=Bunch(name='pod2'))
+            Bunch(spec=Bunch(completions='1', parallelism='1'),
+                  metadata=Bunch(name='pod1')),
+            Bunch(spec=Bunch(completions='2', parallelism='2'),
+                  metadata=Bunch(name='pod2'))
         ])
 
     def patch_namespaced_deployment(self, *args, **kwargs):
+        if self.fail:
+            raise kubernetes.client.rest.ApiException('thrown on purpose')
         return Bunch(items=[Bunch(spec=Bunch(replicas='4'),
                                   metadata=Bunch(name='pod'))])
 
     def patch_namespaced_job(self, *args, **kwargs):
-        return Bunch(items=[Bunch(spec=Bunch(completions='0'),
+        if self.fail:
+            raise kubernetes.client.rest.ApiException('thrown on purpose')
+        return Bunch(items=[Bunch(spec=Bunch(completions='0', parallelism='0'),
                                   metadata=Bunch(name='pod'))])
 
 
@@ -131,8 +145,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
 
     def test_hget(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        kube_client = DummyKubernetes()
-        scaler = autoscaler.Autoscaler(redis_client, kube_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
                                        backoff_seconds=0.01)
         data = scaler.hget('rhash_new', 'status')
         assert data == 'new'
@@ -141,8 +154,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
     def test_scan_iter(self):
         prefix = 'predict'
         redis_client = DummyRedis(fail_tolerance=2, prefix=prefix)
-        kube_client = DummyKubernetes()
-        scaler = autoscaler.Autoscaler(redis_client, kube_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
                                        backoff_seconds=0.01)
         data = scaler.scan_iter(match=prefix)
         keys = [k for k in data]
@@ -153,8 +165,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
     def test_get_desired_pods(self):
         # key, keys_per_pod, min_pods, max_pods, current_pods
         redis_client = DummyRedis(fail_tolerance=2)
-        kube_client = DummyKubernetes()
-        scaler = autoscaler.Autoscaler(redis_client, kube_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
                                        backoff_seconds=0.01)
         scaler.redis_keys['predict'] = 10
         # desired_pods is > max_pods
@@ -170,11 +181,51 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         desired_pods = scaler.get_desired_pods('predict', 10, 0, 5, 3)
         assert desired_pods == 3
 
+    def test_list_namespaced_deployment(self):
+        redis_client = DummyRedis(fail_tolerance=2)
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
+                                       backoff_seconds=0.01)
+        # test ApiException is logged and thrown
+        scaler.get_apps_v1_client = lambda: DummyKubernetes(fail=True)
+        with pytest.raises(kubernetes.client.rest.ApiException):
+            scaler.list_namespaced_deployment('ns')
+
+    def test_list_namespaced_job(self):
+        redis_client = DummyRedis(fail_tolerance=2)
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
+                                       backoff_seconds=0.01)
+        # test ApiException is logged and thrown
+        scaler.get_batch_v1_client = lambda: DummyKubernetes(fail=True)
+        with pytest.raises(kubernetes.client.rest.ApiException):
+            scaler.list_namespaced_job('ns')
+
+    def test_patch_namespaced_deployment(self):
+        redis_client = DummyRedis(fail_tolerance=2)
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
+                                       backoff_seconds=0.01)
+        # test ApiException is logged and thrown
+        scaler.get_apps_v1_client = lambda: DummyKubernetes(fail=True)
+        with pytest.raises(kubernetes.client.rest.ApiException):
+            scaler.patch_namespaced_deployment(
+                'pod', 'ns', {'spec': {'replicas': 1}})
+
+    def test_patch_namespaced_job(self):
+        redis_client = DummyRedis(fail_tolerance=2)
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
+                                       backoff_seconds=0.01)
+        # test ApiException is logged and thrown
+        scaler.get_batch_v1_client = lambda: DummyKubernetes(fail=True)
+        with pytest.raises(kubernetes.client.rest.ApiException):
+            scaler.patch_namespaced_job(
+                'job', 'ns', {'spec': {'parallelism': 1}})
+
     def test_get_current_pods(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        kube_client = DummyKubernetes()
-        scaler = autoscaler.Autoscaler(redis_client, kube_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
                                        backoff_seconds=0.01)
+
+        scaler.get_apps_v1_client = DummyKubernetes
+        scaler.get_batch_v1_client = DummyKubernetes
 
         # test invalid resource_type
         with pytest.raises(ValueError):
@@ -194,15 +245,14 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
 
     def test_tally_keys(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        kube_client = DummyKubernetes()
-        scaler = autoscaler.Autoscaler(redis_client, kube_client, 'None',
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
                                        backoff_seconds=0.01)
         scaler.tally_keys()
         assert scaler.redis_keys == {'predict': 2, 'train': 2}
 
     def test_scale_deployments(self):
+        dummy_kube = lambda: DummyKubernetes()
         redis_client = DummyRedis(fail_tolerance=2)
-        kube_client = DummyKubernetes()
         deploy_params = ['0', '1', '3', 'ns', 'deployment', 'predict', 'name']
         job_params = ['1', '2', '1', 'ns', 'job', 'train', 'name']
 
@@ -215,14 +265,14 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         bad_params = ['f0', 'f1', 'f3', 'ns', 'job', 'train', 'name']
         p = deployment_delim.join([param_delim.join(bad_params)])
 
-        scaler = autoscaler.Autoscaler(redis_client, kube_client, p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, p, 0,
                                        deployment_delim, param_delim)
         scaler.scale_deployments()
 
         # not enough params will warn, but not raise (or autoscale)
         bad_params = ['0', '1', '3', 'ns', 'job', 'train']
         p = deployment_delim.join([param_delim.join(bad_params)])
-        scaler = autoscaler.Autoscaler(redis_client, kube_client, p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, p, 0,
                                        deployment_delim, param_delim)
         scaler.scale_deployments()
 
@@ -230,7 +280,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         with pytest.raises(ValueError):
             bad_params = ['0', '1', '3', 'ns', 'bad_type', 'train', 'name']
             p = deployment_delim.join([param_delim.join(bad_params)])
-            scaler = autoscaler.Autoscaler(redis_client, kube_client, p, 0,
+            scaler = autoscaler.Autoscaler(redis_client, p, 0,
                                            deployment_delim, param_delim)
             scaler.scale_deployments()
 
@@ -240,9 +290,13 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         params = [deploy_params, job_params]
         p = deployment_delim.join([param_delim.join(p) for p in params])
 
-        scaler = autoscaler.Autoscaler(redis_client, kube_client, p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, p, 0,
                                        deployment_delim,
                                        param_delim)
+
+        scaler.get_apps_v1_client = dummy_kube
+        scaler.get_batch_v1_client = dummy_kube
+
         scaler.scale_deployments()
         # test desired_pods == current_pods
         scaler.get_desired_pods = lambda *x: 4
@@ -253,4 +307,26 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
             param_delim = '|'
             deployment_delim = '|'
             p = deployment_delim.join([param_delim.join(p) for p in params])
-            autoscaler.Autoscaler(None, None, p, 0, deployment_delim, param_delim)
+            autoscaler.Autoscaler(None, p, 0, deployment_delim, param_delim)
+
+    def test_scale(self):
+        redis_client = DummyRedis(fail_tolerance=2)
+        scaler = autoscaler.Autoscaler(redis_client, 'None',
+                                       backoff_seconds=0.01)
+
+        global counter
+        counter = 0
+
+        def dummy_tally():
+            global counter
+            counter += 1
+
+        def dummy_scale_deployments():
+            global counter
+            counter += 1
+
+        scaler.tally_keys = dummy_tally
+        scaler.scale_deployments = dummy_scale_deployments
+
+        scaler.scale()
+        assert counter == 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-numpy
 redis==3.2.1
 kubernetes==9.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-redis
 numpy
+redis==3.2.1
+kubernetes==9.0.0


### PR DESCRIPTION
Replace the subprocess commands with Kubernetes client API calls.  The API client is generated on each request, as the API itself differs for jobs and deployments.

Added tests bringing coverage to 97%.  The only untested functions are the helper functions to create the various API clients.

Fixes #7 