### PR TITLE
Check `type` of each redis key before processing it

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ disable=
     too-few-public-methods,
     wildcard-import,
     mixed-indentation,
-    redefined-variable-type
+    redefined-variable-type,
+    useless-object-inheritance
 
 
 [REPORTS]

--- a/autoscale.py
+++ b/autoscale.py
@@ -75,13 +75,12 @@ if __name__ == '__main__':
     REDIS_CLIENT = autoscaler.redis.RedisClient(
         host=os.getenv('REDIS_HOST'),
         port=os.getenv('REDIS_PORT'),
-        backoff=1)
+        backoff=os.getenv('REDIS_INTERVAL', '1'))
 
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,
         scaling_config=os.getenv('AUTOSCALING'),
-        secondary_scaling_config=os.getenv('SECONDARY_AUTOSCALING'),
-        backoff_seconds=os.getenv('REDIS_INTERVAL', '1'))
+        secondary_scaling_config=os.getenv('SECONDARY_AUTOSCALING'))
 
     INTERVAL = int(os.getenv('INTERVAL', '5'))
 

--- a/autoscale.py
+++ b/autoscale.py
@@ -37,8 +37,6 @@ import time
 import logging
 import logging.handlers
 
-import redis
-
 import autoscaler
 
 
@@ -74,11 +72,10 @@ if __name__ == '__main__':
 
     _logger = logging.getLogger(__file__)
 
-    REDIS_CLIENT = redis.StrictRedis(
+    REDIS_CLIENT = autoscaler.redis.RedisClient(
         host=os.getenv('REDIS_HOST'),
         port=os.getenv('REDIS_PORT'),
-        decode_responses=True,
-        charset='utf-8')
+        backoff=1)
 
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,

--- a/autoscaler/__init__.py
+++ b/autoscaler/__init__.py
@@ -27,6 +27,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from autoscaler import redis
+
 from autoscaler.autoscaler import Autoscaler
 
 del absolute_import

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -110,20 +110,14 @@ class Autoscaler(object):
 
     def get_apps_v1_client(self):
         """Returns Kubernetes API Client for AppsV1Api"""
-        t = timeit.default_timer()
         kubernetes.config.load_incluster_config()
         kube_client = kubernetes.client.AppsV1Api()
-        self.logger.debug('Created AppsV1Api client in %s seconds.',
-                          timeit.default_timer() - t)
         return kube_client
 
     def get_batch_v1_client(self):
         """Returns Kubernetes API Client for AppsV1Api"""
-        t = timeit.default_timer()
         kubernetes.config.load_incluster_config()
         kube_client = kubernetes.client.BatchV1Api()
-        self.logger.debug('Created BatchV1Api client in %s seconds.',
-                          timeit.default_timer() - t)
         return kube_client
 
     def list_namespaced_deployment(self, namespace):

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -35,7 +35,7 @@ import logging
 import kubernetes
 
 
-class Autoscaler(object):  # pylint: disable=useless-object-inheritance
+class Autoscaler(object):
     """Read Redis and scale up k8s pods if required.
 
     Args:

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -93,7 +93,7 @@ class Autoscaler(object):
 
         for key in self.redis_client.scan_iter(count=1000):
             if any(re.match(k, key) for k in self.redis_keys):
-                if not self.redis_client.type(key) != 'hash':
+                if self.redis_client.type(key) != 'hash':
                     continue
 
                 status = self.redis_client.hget(key, 'status')

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -29,11 +29,9 @@ from __future__ import division
 from __future__ import print_function
 
 import re
-import time
 import timeit
 import logging
 
-import redis
 import kubernetes
 
 
@@ -44,21 +42,18 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
         redis_client: Redis Client Connection object.
         scaling_config: string, joined lists of autoscaling configurations
         secondary_scaling_config: string, defines initial pod counts
-        backoff_seconds: int, after a redis/subprocess error, sleep for this
-            many seconds and retry the command.
         deployment_delim: string, character delimiting deployment configs.
         param_delim: string, character delimiting deployment config parameters.
     """
 
     def __init__(self, redis_client, scaling_config, secondary_scaling_config,
-                 backoff_seconds=1, deployment_delim=';', param_delim='|'):
+                 deployment_delim=';', param_delim='|'):
 
         if deployment_delim == param_delim:
             raise ValueError('`deployment_delim` and `param_delim` must be '
                              'different. Got "{}" and "{}".'.format(
                                  deployment_delim, param_delim))
         self.redis_client = redis_client
-        self.backoff_seconds = int(backoff_seconds)
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.completed_statuses = {'done', 'failed'}
 
@@ -87,32 +82,6 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
         return [x.split(param_delim)
                 for x in scaling_config.split(deployment_delim)]
 
-    def scan_iter(self, match=None, count=1000):
-        while True:
-            try:
-                response = self.redis_client.scan_iter(match=match, count=count)
-                break
-            except redis.exceptions.ConnectionError as err:
-                self.logger.warning('Encountered %s: %s when calling SCAN. '
-                                    'Retrying in %s seconds.',
-                                    type(err).__name__, err,
-                                    self.backoff_seconds)
-                time.sleep(self.backoff_seconds)
-        return response
-
-    def hget(self, rhash, key):
-        while True:
-            try:
-                response = self.redis_client.hget(rhash, key)
-                break
-            except redis.exceptions.ConnectionError as err:
-                self.logger.warning('Encountered %s: %s when calling HGET. '
-                                    'Retrying in %s seconds.',
-                                    type(err).__name__, err,
-                                    self.backoff_seconds)
-                time.sleep(self.backoff_seconds)
-        return response
-
     def tally_keys(self):
         start = timeit.default_timer()
         # reset the key tallies to 0
@@ -122,9 +91,12 @@ class Autoscaler(object):  # pylint: disable=useless-object-inheritance
         self.logger.debug('Tallying keys in redis matching: `%s`',
                           ', '.join(self.redis_keys.keys()))
 
-        for key in self.scan_iter(count=1000):
+        for key in self.redis_client.scan_iter(count=1000):
             if any(re.match(k, key) for k in self.redis_keys):
-                status = self.hget(key, 'status')
+                if not self.redis_client.type(key) != 'hash':
+                    continue
+
+                status = self.redis_client.hget(key, 'status')
 
                 # add up each type of key that is "in-progress" or "new"
                 if status is not None and status not in self.completed_statuses:

--- a/autoscaler/autoscaler_test.py
+++ b/autoscaler/autoscaler_test.py
@@ -29,7 +29,6 @@ from __future__ import division
 from __future__ import print_function
 
 import pytest
-import redis
 import kubernetes
 
 import autoscaler
@@ -94,7 +93,7 @@ class DummyRedis(object):
         return False
 
     def type(self, rhash):
-        return 'hash' if 'bad' in rhash else 'list'
+        return 'hash'
 
 
 class DummyKubernetes(object):
@@ -102,7 +101,7 @@ class DummyKubernetes(object):
     def __init__(self, fail=False):
         self.fail = fail
 
-    def list_namespaced_deployment(self, *args, **kwargs):
+    def list_namespaced_deployment(self, *_, **__):
         if self.fail:
             raise kubernetes.client.rest.ApiException('thrown on purpose')
         return Bunch(items=[
@@ -114,7 +113,7 @@ class DummyKubernetes(object):
                   status=Bunch(available_replicas='8')),
         ])
 
-    def list_namespaced_job(self, *args, **kwargs):
+    def list_namespaced_job(self, *_, **__):
         if self.fail:
             raise kubernetes.client.rest.ApiException('thrown on purpose')
         return Bunch(items=[
@@ -124,13 +123,13 @@ class DummyKubernetes(object):
                   metadata=Bunch(name='pod2'))
         ])
 
-    def patch_namespaced_deployment(self, *args, **kwargs):
+    def patch_namespaced_deployment(self, *_, **__):
         if self.fail:
             raise kubernetes.client.rest.ApiException('thrown on purpose')
         return Bunch(items=[Bunch(spec=Bunch(replicas='4'),
                                   metadata=Bunch(name='pod'))])
 
-    def patch_namespaced_job(self, *args, **kwargs):
+    def patch_namespaced_job(self, *_, **__):
         if self.fail:
             raise kubernetes.client.rest.ApiException('thrown on purpose')
         return Bunch(items=[Bunch(spec=Bunch(completions='0', parallelism='0'),

--- a/autoscaler/autoscaler_test.py
+++ b/autoscaler/autoscaler_test.py
@@ -40,18 +40,14 @@ class Bunch(object):
         self.__dict__.update(kwds)
 
 
-class DummyRedis(object):  # pylint: disable=useless-object-inheritance
+class DummyRedis(object):
 
-    def __init__(self, prefix='predict', status='new', fail_tolerance=0):
+    def __init__(self, prefix='predict', status='new'):
         self.prefix = '/'.join(x for x in prefix.split('/') if x)
         self.status = status
         self.fail_count = 0
-        self.fail_tolerance = fail_tolerance
 
     def keys(self):
-        if self.fail_count < self.fail_tolerance:
-            self.fail_count += 1
-            raise redis.exceptions.ConnectionError('thrown on purpose')
         return [
             '{}_{}_{}'.format(self.prefix, self.status, 'x.tiff'),
             '{}_{}_{}'.format(self.prefix, 'failed', 'x.zip'),
@@ -62,10 +58,6 @@ class DummyRedis(object):  # pylint: disable=useless-object-inheritance
         ]
 
     def scan_iter(self, match=None, count=None):
-        if self.fail_count < self.fail_tolerance:
-            self.fail_count += 1
-            raise redis.exceptions.ConnectionError('thrown on purpose')
-
         keys = [
             '{}_{}_{}'.format(self.prefix, self.status, 'x.tiff'),
             '{}_{}_{}'.format(self.prefix, 'failed', 'x.zip'),
@@ -91,9 +83,6 @@ class DummyRedis(object):  # pylint: disable=useless-object-inheritance
                         yield k
 
     def hget(self, rhash, field):
-        if self.fail_count < self.fail_tolerance:
-            self.fail_count += 1
-            raise redis.exceptions.ConnectionError('thrown on purpose')
         if field == 'status':
             return rhash.split('_')[1]
         elif field == 'file_name':
@@ -103,6 +92,9 @@ class DummyRedis(object):  # pylint: disable=useless-object-inheritance
         elif field == 'output_file_name':
             return rhash.split('_')[-1]
         return False
+
+    def type(self, rhash):
+        return 'hash' if 'bad' in rhash else 'list'
 
 
 class DummyKubernetes(object):
@@ -145,32 +137,12 @@ class DummyKubernetes(object):
                                   metadata=Bunch(name='pod'))])
 
 
-class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
-
-    def test_hget(self):
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
-        data = scaler.hget('rhash_new', 'status')
-        assert data == 'new'
-        assert scaler.redis_client.fail_count == redis_client.fail_tolerance
-
-    def test_scan_iter(self):
-        prefix = 'predict'
-        redis_client = DummyRedis(fail_tolerance=2, prefix=prefix)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
-        data = scaler.scan_iter(match=prefix)
-        keys = [k for k in data]
-        expected = [k for k in redis_client.keys() if k.startswith(prefix)]
-        assert scaler.redis_client.fail_count == redis_client.fail_tolerance
-        assert keys == expected
+class TestAutoscaler(object):
 
     def test_get_desired_pods(self):
         # key, keys_per_pod, min_pods, max_pods, current_pods
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
+        redis_client = DummyRedis()
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None')
         scaler.redis_keys['predict'] = 10
         # desired_pods is > max_pods
         desired_pods = scaler.get_desired_pods('predict', 2, 0, 2, 1)
@@ -188,9 +160,8 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
     def test_get_secondary_desired_pods(self):
         # reference_pods, pods_per_reference_pod,
         # min_pods, max_pods, current_pods
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
+        redis_client = DummyRedis()
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None')
 
         # desired_pods is > max_pods
         desired_pods = scaler.get_secondary_desired_pods(1, 10, 0, 4, 4)
@@ -212,27 +183,24 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         assert desired_pods == 10
 
     def test_list_namespaced_deployment(self):
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
+        redis_client = DummyRedis()
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None')
         # test ApiException is logged and thrown
         scaler.get_apps_v1_client = lambda: DummyKubernetes(fail=True)
         with pytest.raises(kubernetes.client.rest.ApiException):
             scaler.list_namespaced_deployment('ns')
 
     def test_list_namespaced_job(self):
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
+        redis_client = DummyRedis()
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None')
         # test ApiException is logged and thrown
         scaler.get_batch_v1_client = lambda: DummyKubernetes(fail=True)
         with pytest.raises(kubernetes.client.rest.ApiException):
             scaler.list_namespaced_job('ns')
 
     def test_patch_namespaced_deployment(self):
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
+        redis_client = DummyRedis()
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None')
         # test ApiException is logged and thrown
         scaler.get_apps_v1_client = lambda: DummyKubernetes(fail=True)
         with pytest.raises(kubernetes.client.rest.ApiException):
@@ -240,9 +208,8 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
                 'pod', 'ns', {'spec': {'replicas': 1}})
 
     def test_patch_namespaced_job(self):
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
+        redis_client = DummyRedis()
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None')
         # test ApiException is logged and thrown
         scaler.get_batch_v1_client = lambda: DummyKubernetes(fail=True)
         with pytest.raises(kubernetes.client.rest.ApiException):
@@ -250,9 +217,8 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
                 'job', 'ns', {'spec': {'parallelism': 1}})
 
     def test_get_current_pods(self):
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
+        redis_client = DummyRedis()
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None')
 
         scaler.get_apps_v1_client = DummyKubernetes
         scaler.get_batch_v1_client = DummyKubernetes
@@ -280,14 +246,13 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         assert deployed_pods == 2
 
     def test_tally_keys(self):
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
+        redis_client = DummyRedis()
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None')
         scaler.tally_keys()
         assert scaler.redis_keys == {'predict': 2, 'train': 2}
 
     def test_scale_primary_resources(self):
-        redis_client = DummyRedis(fail_tolerance=2)
+        redis_client = DummyRedis()
         deploy_params = ['0', '1', '3', 'ns', 'deployment', 'predict', 'name']
         job_params = ['1', '2', '1', 'ns', 'job', 'train', 'name']
 
@@ -299,7 +264,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         # non-integer values will warn, but not raise (or autoscale)
         bad_params = ['f0', 'f1', 'f3', 'ns', 'job', 'train', 'name']
         p = deployment_delim.join([param_delim.join(bad_params)])
-        scaler = autoscaler.Autoscaler(redis_client, p, 'None', 0,
+        scaler = autoscaler.Autoscaler(redis_client, p, 'None',
                                        deployment_delim, param_delim)
         scaler.get_apps_v1_client = DummyKubernetes
         scaler.get_batch_v1_client = DummyKubernetes
@@ -308,7 +273,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         # not enough params will warn, but not raise (or autoscale)
         bad_params = ['0', '1', '3', 'ns', 'job', 'train']
         p = deployment_delim.join([param_delim.join(bad_params)])
-        scaler = autoscaler.Autoscaler(redis_client, p, 'None', 0,
+        scaler = autoscaler.Autoscaler(redis_client, p, 'None',
                                        deployment_delim, param_delim)
         scaler.get_apps_v1_client = DummyKubernetes
         scaler.get_batch_v1_client = DummyKubernetes
@@ -318,7 +283,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         with pytest.raises(ValueError):
             bad_params = ['0', '1', '3', 'ns', 'bad_type', 'train', 'name']
             p = deployment_delim.join([param_delim.join(bad_params)])
-            scaler = autoscaler.Autoscaler(redis_client, p, 'None', 0,
+            scaler = autoscaler.Autoscaler(redis_client, p, 'None',
                                            deployment_delim, param_delim)
             scaler.get_apps_v1_client = DummyKubernetes
             scaler.get_batch_v1_client = DummyKubernetes
@@ -330,9 +295,8 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         params = [deploy_params, job_params]
         p = deployment_delim.join([param_delim.join(p) for p in params])
 
-        scaler = autoscaler.Autoscaler(redis_client, p, 'None', 0,
-                                       deployment_delim,
-                                       param_delim)
+        scaler = autoscaler.Autoscaler(redis_client, p, 'None',
+                                       deployment_delim, param_delim)
 
         scaler.get_apps_v1_client = DummyKubernetes
         scaler.get_batch_v1_client = DummyKubernetes
@@ -347,14 +311,14 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
             param_delim = '|'
             deployment_delim = '|'
             p = deployment_delim.join([param_delim.join(p) for p in params])
-            autoscaler.Autoscaler(None, p, 'None', 0,
+            autoscaler.Autoscaler(None, p, 'None',
                                   deployment_delim, param_delim)
 
     def test_scale_secondary_resources(self):
         # redis-deployment|deployment|namespace|tf-serving-deployment|
         # deployment|namespace2|podRatio|minPods|maxPods
 
-        redis_client = DummyRedis(fail_tolerance=2)
+        redis_client = DummyRedis()
         deploy_params = ['name', 'deployment', 'ns',
                          'primary', 'deployment', 'ns',
                          '7', '1', '10']
@@ -372,7 +336,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
                       'primary', 'bad_type', 'ns',
                       'f7', 'f1', 'f10']
         p = deployment_delim.join([param_delim.join(bad_params)])
-        scaler = autoscaler.Autoscaler(redis_client, 'None', p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, 'None', p,
                                        deployment_delim, param_delim)
         scaler.get_apps_v1_client = DummyKubernetes
         scaler.get_batch_v1_client = DummyKubernetes
@@ -381,7 +345,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         # not enough params will warn, but not raise (or autoscale)
         bad_params = ['name', 'job', 'ns', 'primary', 'job', '7', '1', '10']
         p = deployment_delim.join([param_delim.join(bad_params)])
-        scaler = autoscaler.Autoscaler(redis_client, 'None', p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, 'None', p,
                                        deployment_delim, param_delim)
         scaler.get_apps_v1_client = DummyKubernetes
         scaler.get_batch_v1_client = DummyKubernetes
@@ -393,7 +357,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
                           'primary', 'bad_type', 'ns',
                           '7', '1', '10']
             p = deployment_delim.join([param_delim.join(bad_params)])
-            scaler = autoscaler.Autoscaler(redis_client, 'None', p, 0,
+            scaler = autoscaler.Autoscaler(redis_client, 'None', p,
                                            deployment_delim, param_delim)
             scaler.get_apps_v1_client = DummyKubernetes
             scaler.get_batch_v1_client = DummyKubernetes
@@ -403,7 +367,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         params = [deploy_params, job_params]
         p = deployment_delim.join([param_delim.join(p) for p in params])
 
-        scaler = autoscaler.Autoscaler(redis_client, 'None', p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, 'None', p,
                                        deployment_delim, param_delim)
 
         scaler.get_apps_v1_client = DummyKubernetes
@@ -418,7 +382,7 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
         params = [deploy_params, job_params]
         p = deployment_delim.join([param_delim.join(p) for p in params])
 
-        scaler = autoscaler.Autoscaler(redis_client, 'None', p, 0,
+        scaler = autoscaler.Autoscaler(redis_client, 'None', p,
                                        deployment_delim, param_delim)
 
         scaler.get_apps_v1_client = DummyKubernetes
@@ -458,13 +422,12 @@ class TestAutoscaler(object):  # pylint: disable=useless-object-inheritance
             param_delim = '|'
             deployment_delim = '|'
             p = deployment_delim.join([param_delim.join(p) for p in params])
-            autoscaler.Autoscaler(None, 'None', p, 0,
+            autoscaler.Autoscaler(None, 'None', p,
                                   deployment_delim, param_delim)
 
     def test_scale(self):
-        redis_client = DummyRedis(fail_tolerance=2)
-        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None',
-                                       backoff_seconds=0.01)
+        redis_client = DummyRedis()
+        scaler = autoscaler.Autoscaler(redis_client, 'None', 'None')
 
         global counter
         counter = 0

--- a/autoscaler/redis.py
+++ b/autoscaler/redis.py
@@ -1,0 +1,71 @@
+# Copyright 2016-2019 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/kiosk-autoscaler/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Fault tolerant Redis client wrapper class"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import time
+import logging
+
+import redis
+
+
+class RedisClient(object):
+
+    def __init__(self, host, port, backoff=1):
+        self.logger = logging.getLogger(str(self.__class__.__name__))
+        self.backoff = backoff
+        self._redis = self._get_redis_client(host=host, port=port)
+
+    def _get_redis_client(self, host, port):  # pylint: disable=R0201
+        return redis.StrictRedis(
+            host=host, port=port,
+            decode_responses=True,
+            charset='utf-8')
+
+    def __getattr__(self, name):
+        redis_function = getattr(self._redis, name)
+
+        def wrapper(*args, **kwargs):
+            while True:
+                try:
+                    return redis_function(*args, **kwargs)
+                except redis.exceptions.ConnectionError as err:
+                    values = list(args) + list(kwargs.values())
+                    self.logger.warning('Encountered %s: %s when calling '
+                                        '`%s %s`. Retrying in %s seconds.',
+                                        type(err).__name__, err,
+                                        str(name).upper(),
+                                        ' '.join(values), self.backoff)
+                    time.sleep(self.backoff)
+                except Exception as err:
+                    self.logger.error('Unexpected %s: %s when calling %s.',
+                                      type(err).__name__, err,
+                                      str(name).upper())
+                    raise err
+
+        return wrapper

--- a/autoscaler/redis_test.py
+++ b/autoscaler/redis_test.py
@@ -1,0 +1,80 @@
+# Copyright 2016-2019 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/kiosk-autoscaler/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for Redis client wrapper class"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import random
+
+import redis
+import pytest
+
+import autoscaler
+
+
+class DummyRedis(object):
+    def __init__(self, fail_tolerance=0, hard_fail=False):
+        self.fail_count = 0
+        self.fail_tolerance = fail_tolerance
+        self.hard_fail = hard_fail
+
+    def get_fail_count(self):
+        if self.hard_fail:
+            raise AssertionError('thrown on purpose')
+        if self.fail_count < self.fail_tolerance:
+            self.fail_count += 1
+            raise redis.exceptions.ConnectionError('thrown on purpose')
+        return self.fail_count
+
+
+class TestRedis(object):
+
+    def test_redis_client(self):  # pylint: disable=R0201
+        fails = random.randint(1, 3)
+        Redis = autoscaler.redis.RedisClient
+
+        # monkey patch _get_redis_client function to use DummyRedis client
+        def _get_redis_client(*args, **kwargs):  # pylint: disable=W0613
+            return DummyRedis(fail_tolerance=fails)
+
+        Redis._get_redis_client = _get_redis_client
+
+        client = Redis(host='host', port='port', backoff=0)
+        assert client.get_fail_count() == fails
+
+        with pytest.raises(AttributeError):
+            client.unknown_function()
+
+        # test that other exceptions will raise.
+        def _get_redis_client_bad(*args, **kwargs):  # pylint: disable=W0613
+            return DummyRedis(fail_tolerance=fails, hard_fail=True)
+
+        Redis._get_redis_client = _get_redis_client_bad
+
+        client = Redis(host='host', port='port', backoff=0)
+        with pytest.raises(AssertionError):
+            client.get_fail_count()


### PR DESCRIPTION
Only keys of `type="hash"` should be processed by the autoscaler, as it calls hget on each key.