### PR TITLE
Process environment variables with python-decouple

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.6
+FROM python:3.6-alpine
 
 WORKDIR /usr/src/app
 
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -338,8 +338,13 @@ class Autoscaler(object):
                               str(resource_type).capitalize(), name,
                               namespace, current_pods, desired_pods)
 
-            self.scale_resource(desired_pods, current_pods,
-                                resource_type, namespace, name)
+            try:
+                self.scale_resource(desired_pods, current_pods,
+                                    resource_type, namespace, name)
+            except kubernetes.client.rest.ApiException as err:
+                self.logger.warning('Failed to scale %s `%s.%s` due to %s: %s',
+                                    resource_type, namespace, name,
+                                    type(err).__name__, err)
 
     def scale(self):
         self.tally_queues()

--- a/autoscaler/autoscaler_test.py
+++ b/autoscaler/autoscaler_test.py
@@ -274,6 +274,13 @@ class TestAutoscaler(object):
         scaler.get_desired_pods = lambda *x: 4
         scaler.scale_resources()
 
+        # test failure to scale does not crash
+        def fail_to_scale(*_, **__):
+            raise kubernetes.client.rest.ApiException(404)
+
+        scaler.scale_resource = fail_to_scale
+        scaler.scale_resources()
+
         # same delimiter throws an error;
         with pytest.raises(ValueError):
             param_delim = '|'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-redis==3.2.1
 kubernetes==9.0.0
+python-decouple>=3.1,<4
+redis==3.2.1

--- a/scale.py
+++ b/scale.py
@@ -34,6 +34,8 @@ import time
 import logging
 import logging.handlers
 
+from decouple import config
+
 import autoscaler
 
 
@@ -70,15 +72,15 @@ if __name__ == '__main__':
     _logger = logging.getLogger(__file__)
 
     REDIS_CLIENT = autoscaler.redis.RedisClient(
-        host=os.getenv('REDIS_HOST'),
-        port=os.getenv('REDIS_PORT'),
-        backoff=int(os.getenv('REDIS_INTERVAL', '1')))
+        host=config('REDIS_HOST', cast=str),
+        port=config('REDIS_PORT', default=6379, cast=int),
+        backoff=config('REDIS_INTERVAL', default=1, cast=int))
 
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,
-        scaling_config=os.getenv('AUTOSCALING'))
+        scaling_config=config('AUTOSCALING'))
 
-    INTERVAL = int(os.getenv('INTERVAL', '5'))
+    INTERVAL = config('INTERVAL', default=5, cast=int)
 
     while True:
         try:

--- a/scale.py
+++ b/scale.py
@@ -28,13 +28,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-import sys
-import time
 import logging
 import logging.handlers
+import sys
+import time
 
-from decouple import config
+import decouple
 
 import autoscaler
 
@@ -72,15 +71,15 @@ if __name__ == '__main__':
     _logger = logging.getLogger(__file__)
 
     REDIS_CLIENT = autoscaler.redis.RedisClient(
-        host=config('REDIS_HOST', cast=str),
-        port=config('REDIS_PORT', default=6379, cast=int),
-        backoff=config('REDIS_INTERVAL', default=1, cast=int))
+        host=decouple.config('REDIS_HOST', cast=str),
+        port=decouple.config('REDIS_PORT', default=6379, cast=int),
+        backoff=decouple.config('REDIS_INTERVAL', default=1, cast=int))
 
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,
-        scaling_config=config('AUTOSCALING'))
+        scaling_config=decouple.config('AUTOSCALING'))
 
-    INTERVAL = config('INTERVAL', default=5, cast=int)
+    INTERVAL = decouple.config('INTERVAL', default=5, cast=int)
 
     while True:
         try:


### PR DESCRIPTION
python-decouple provides nice environment variable parsing and casting. Much more robust than just `os.getenv`.

Additionally, this PR fixes #7 and merely warns when `scale_resource` gets a 404 error, instead of crashing.