### PR TITLE
Add new keys from AUTOSCALING_PARAMS to redis_keys

### DIFF
--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -55,6 +55,13 @@ class Autoscaler(object):
                              'different. Got "{}" and "{}".'.format(
                                  deployment_delim, param_delim))
 
+        self.redis_keys = {
+            'predict': 0,
+            'train': 0,
+            'track': 0,
+            'notebook',
+        }
+
         self.redis_client = redis_client
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.completed_statuses = {'done', 'failed'}
@@ -63,12 +70,6 @@ class Autoscaler(object):
             scaling_config=scaling_config.rstrip(),
             deployment_delim=deployment_delim,
             param_delim=param_delim)
-
-        self.redis_keys = {
-            'predict': 0,
-            'train': 0,
-            'track': 0
-        }
 
         self.managed_resource_types = {'deployment', 'job'}
 

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -59,7 +59,6 @@ class Autoscaler(object):
             'predict': 0,
             'train': 0,
             'track': 0,
-            'notebook',
         }
 
         self.redis_client = redis_client
@@ -94,12 +93,17 @@ class Autoscaler(object):
                 if namespace_resource_type_name not in params:
                     params[namespace_resource_type_name] = []
 
+                prefix = str(entry[5]).strip()
+
                 params[namespace_resource_type_name].append({
                     'min_pods': int(entry[0]),
                     'max_pods': int(entry[1]),
                     'keys_per_pod': int(entry[2]),
-                    'prefix': str(entry[5]).strip(),
+                    'prefix': prefix,
                 })
+
+                if prefix not in self.redis_keys:
+                    self.redis_keys[prefix] = 0
 
             except (IndexError, ValueError):
                 self.logger.error('Autoscaling entry %s is malformed.', entry)

--- a/autoscaler/autoscaler_test.py
+++ b/autoscaler/autoscaler_test.py
@@ -98,15 +98,14 @@ class TestAutoscaler(object):
         primary_params = """
             1|2|3|namespace|resource_1|predict|name_1;
             4|5|6|namespace|resource_1|track|name_1;
-            7|8|9|namespace|resource_2|train|name_1
+            7|8|9|namespace|resource_2|train|name_1;
+            7|8|9|namespace|resource_3|newkey|name_1
             """.strip()
 
         redis_client = DummyRedis()
         scaler = autoscaler.Autoscaler(redis_client,
                                        primary_params)
-        print("printing primary autoscaling parameters")
-        print(scaler.autoscaling_params)
-        print("done printing")
+
         assert scaler.autoscaling_params == {
             ('namespace', 'resource_1', 'name_1'): [
                 {
@@ -125,6 +124,14 @@ class TestAutoscaler(object):
             ('namespace', 'resource_2', 'name_1'): [
                 {
                     "prefix": "train",
+                    "min_pods": 7,
+                    "max_pods": 8,
+                    "keys_per_pod": 9
+                }
+            ],
+            ('namespace', 'resource_3', 'name_1'): [
+                {
+                    "prefix": "newkey",
                     "min_pods": 7,
                     "max_pods": 8,
                     "keys_per_pod": 9


### PR DESCRIPTION
If a key is found in `AUTOSCALING_PARAMS` which is not explicitly hard-coded in `self.redis_keys`, then this key will be added with a default value of 0.  This enables users to quickly and easily extend the autoscaling usage via environmental variables.