### PR TITLE
Update the Redis client wrapper with Sentinel support

### DIFF
--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -133,14 +133,12 @@ class Autoscaler(object):
     def get_apps_v1_client(self):
         """Returns Kubernetes API Client for AppsV1Api"""
         kubernetes.config.load_incluster_config()
-        kube_client = kubernetes.client.AppsV1Api()
-        return kube_client
+        return kubernetes.client.AppsV1Api()
 
     def get_batch_v1_client(self):
         """Returns Kubernetes API Client for AppsV1Api"""
         kubernetes.config.load_incluster_config()
-        kube_client = kubernetes.client.BatchV1Api()
-        return kube_client
+        return kubernetes.client.BatchV1Api()
 
     def list_namespaced_deployment(self, namespace):
         """Wrapper for `kubernetes.client.list_namespaced_deployment`"""

--- a/autoscaler/redis.py
+++ b/autoscaler/redis.py
@@ -171,6 +171,7 @@ class RedisClient(object):
 
         def wrapper(*args, **kwargs):
             values = list(args) + list(kwargs.values())
+            values = [str(v) for v in values]
             while True:
                 try:
                     return redis_function(*args, **kwargs)

--- a/autoscaler/redis.py
+++ b/autoscaler/redis.py
@@ -154,7 +154,8 @@ class RedisClient(object):
             self.logger.warning('Encountered Error: %s. Using sentinel as '
                                 'primary redis client.', err)
 
-    def _get_redis_client(self, host, port):  # pylint: disable=R0201
+    @classmethod
+    def _get_redis_client(cls, host, port):
         return redis.StrictRedis(host=host, port=port,
                                  decode_responses=True,
                                  charset='utf-8')

--- a/autoscaler/redis.py
+++ b/autoscaler/redis.py
@@ -182,6 +182,17 @@ class RedisClient(object):
                                         str(name).upper(),
                                         ' '.join(values), self.backoff)
                     time.sleep(self.backoff)
+                except redis.exceptions.ResponseError as err:
+                    # check if redis just needs a backoff
+                    if 'BUSY' in str(err) and 'SCRIPT KILL' in str(err):
+                        self.logger.warning('Encountered %s: %s when calling '
+                                            '`%s %s`. Retrying in %s seconds.',
+                                            type(err).__name__, err,
+                                            str(name).upper(),
+                                            ' '.join(values), self.backoff)
+                        time.sleep(self.backoff)
+                    else:
+                        raise err
                 except Exception as err:
                     self.logger.error('Unexpected %s: %s when calling `%s %s`.',
                                       type(err).__name__, err,

--- a/autoscaler/redis.py
+++ b/autoscaler/redis.py
@@ -28,10 +28,98 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
 import logging
+import time
+import random
 
 import redis
+
+
+REDIS_READONLY_COMMANDS = {
+    'publish',
+    'sunion',
+    'readonly',
+    'exists',
+    'hstrlen',
+    'lindex',
+    'scan',
+    'ping',
+    'ttl',
+    'wait',
+    'zscore',
+    'zrevrangebylex',
+    'sscan',
+    'geohash',
+    'getbit',
+    'hkeys',
+    'zrange',
+    'llen',
+    'auth',
+    'zcard',
+    'dbsize',
+    'subscribe',
+    'zrangebylex',
+    'zlexcount',
+    'mget',
+    'getrange',
+    'bitpos',
+    'lrange',
+    'discard',
+    'asking',
+    'client',
+    'pfselftest',
+    'unsubscribe',
+    'zrank',
+    'readwrite',
+    'hget',
+    'bitcount',
+    'randomkey',
+    'time',
+    'zrevrank',
+    'sinter',
+    'dump',
+    'strlen',
+    'unwatch',
+    'smembers',
+    'georadius',
+    'lastsave',
+    'slowlog',
+    'sismember',
+    'hexists',
+    'multi',
+    'sdiff',
+    'geopos',
+    'hscan',
+    'script',
+    'keys',
+    'hvals',
+    'pfcount',
+    'zscan',
+    'echo',
+    'command',
+    'select',
+    'zcount',
+    'substr',
+    'pttl',
+    'hlen',
+    'info',
+    'scard',
+    'geodist',
+    'srandmember',
+    'hgetall',
+    'pubsub',
+    'psubscribe',
+    'zrevrange',
+    'hmget',
+    'object',
+    'watch',
+    'zrangebyscore',
+    'get',
+    'type',
+    'zrevrangebyscore',
+    'punsubscribe',
+    'georadiusbymember',
+}
 
 
 class RedisClient(object):
@@ -39,23 +127,54 @@ class RedisClient(object):
     def __init__(self, host, port, backoff=1):
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.backoff = backoff
-        self._redis = self._get_redis_client(host=host, port=port)
+        self._sentinel = self._get_redis_client(host=host, port=port)
+        self._redis_master = self._sentinel
+        self._redis_slaves = [self._sentinel]
+        self._update_masters_and_slaves()
+
+    def _update_masters_and_slaves(self):
+        try:
+            self._sentinel.sentinel_masters()
+
+            sentinel_masters = self._sentinel.sentinel_masters()
+
+            for master_set in sentinel_masters:
+                master = sentinel_masters[master_set]
+
+                redis_master = self._get_redis_client(
+                    master['ip'], master['port'])
+
+                redis_slaves = []
+                for slave in self._sentinel.sentinel_slaves(master_set):
+                    redis_slave = self._get_redis_client(
+                        slave['ip'], slave['port'])
+                    redis_slaves.append(redis_slave)
+
+                self._redis_slaves = redis_slaves
+                self._redis_master = redis_master
+        except redis.exceptions.ResponseError as err:
+            self.logger.warning('Encountered Error: %s. Using sentinel as '
+                                'primary redis client.', err)
 
     def _get_redis_client(self, host, port):  # pylint: disable=R0201
-        return redis.StrictRedis(
-            host=host, port=port,
-            decode_responses=True,
-            charset='utf-8')
+        return redis.StrictRedis(host=host, port=port,
+                                 decode_responses=True,
+                                 charset='utf-8')
 
     def __getattr__(self, name):
-        redis_function = getattr(self._redis, name)
+        if name in REDIS_READONLY_COMMANDS:
+            redis_client = random.choice(self._redis_slaves)
+        else:
+            redis_client = self._redis_master
+
+        redis_function = getattr(redis_client, name)
 
         def wrapper(*args, **kwargs):
+            values = list(args) + list(kwargs.values())
             while True:
                 try:
                     return redis_function(*args, **kwargs)
                 except redis.exceptions.ConnectionError as err:
-                    values = list(args) + list(kwargs.values())
                     self.logger.warning('Encountered %s: %s when calling '
                                         '`%s %s`. Retrying in %s seconds.',
                                         type(err).__name__, err,
@@ -63,9 +182,9 @@ class RedisClient(object):
                                         ' '.join(values), self.backoff)
                     time.sleep(self.backoff)
                 except Exception as err:
-                    self.logger.error('Unexpected %s: %s when calling %s.',
+                    self.logger.error('Unexpected %s: %s when calling `%s %s`.',
                                       type(err).__name__, err,
-                                      str(name).upper())
+                                      str(name).upper(), ' '.join(values))
                     raise err
 
         return wrapper

--- a/autoscaler/redis.py
+++ b/autoscaler/redis.py
@@ -134,8 +134,6 @@ class RedisClient(object):
 
     def _update_masters_and_slaves(self):
         try:
-            self._sentinel.sentinel_masters()
-
             sentinel_masters = self._sentinel.sentinel_masters()
 
             for master_set in sentinel_masters:


### PR DESCRIPTION
The Redis client now uses Sentinel to route READONLY requests to the slave nodes and WRITE request to the master node.