### PR TITLE
pass queues to the autoscaler to dynamically scale different queue names

### DIFF
--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -47,6 +47,8 @@ class Autoscaler(object):
     def __init__(self,
                  redis_client,
                  scaling_config,
+                 queues='predict',
+                 queue_delim=',',
                  deployment_delim=';',
                  param_delim='|'):
 
@@ -55,11 +57,7 @@ class Autoscaler(object):
                              'different. Got "{}" and "{}".'.format(
                                  deployment_delim, param_delim))
 
-        self.redis_keys = {
-            'predict': 0,
-            'train': 0,
-            'track': 0,
-        }
+        self.redis_keys = {q: 0 for q in queues.split(queue_delim)}
 
         self.redis_client = redis_client
         self.logger = logging.getLogger(str(self.__class__.__name__))

--- a/scale.py
+++ b/scale.py
@@ -77,7 +77,8 @@ if __name__ == '__main__':
 
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,
-        scaling_config=decouple.config('AUTOSCALING'))
+        scaling_config=decouple.config('AUTOSCALING'),
+        queues=decouple.config('QUEUES', 'predict,track,train'))
 
     INTERVAL = decouple.config('INTERVAL', default=5, cast=int)
 


### PR DESCRIPTION
Parse environment variables `QUEUES` (a comma-separated string) into a list of different queues.  This value is then passed to the `Autoscaler` which now takes `queues` as an input parameter, replacing the hard-coded `redis_keys`.

Tests have been similarly edited to reduce the number of unnamed parameters to the class.