### PR TITLE
Reconfigure the `AUTOSCALING` parameter for ease-of-use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@ The Autoscaler is configured using environment variables. Please find a table of
 
 | Name | Description | Default Value |
 | :--- | :--- | :--- |
-| `AUTOSCALING` | **REQUIRED**: A list of scaling configurations, associating certain GPU resources with Redis queues. |  |
-| `INTERVAL` | How frequently the autoscaler checks for required resources, in seconds. | `5` |
-| `QUEUES` | A `QUEUE_DELIMITER` separated list of work queues to monitor. | `predict,track` |
+| `QUEUES` | **REQUIRED**: A `QUEUE_DELIMITER` separated list of work queues to monitor. | `predict,track` |
 | `QUEUE_DELIMITER` | A string used to separate a list of queue names in `QUEUES`. | `,` |
+| `RESOURCE_NAME` | **REQUIRED**: The name of the resource to scale. |  |
+| `RESOURCE_TYPE` | The resource type of `RESOURCE_NAME`, one of `deployment` or `job`. | `deployment` |
+| `RESOURCE_NAMESPACE` | The k8s namespace of `RESOURCE_NAME`. | `default` |
+| `INTERVAL` | How frequently the autoscaler checks for required resources, in seconds. | `5` |
 | `REDIS_HOST` | The IP address or hostname of Redis. | `redis-master` |
 | `REDIS_PORT` | The port used to connect to Redis. | `6379` |
 | `REDIS_INTERVAL` | Time to wait between Redis ConnectionErrors, in seconds. | `1` |
+| `MAX_PODS` | The maximum number of pods to scale up. Should be `1`. | `1` |
+| `MIN_PODS` | The minimum number of pods to scale down. Should be `0`. | `0` |
+| `KEYS_PER_POD` | The number of work keys per instance of `RESOURCE_NAME`. Should be `1`. | `1` |

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ The Autoscaler is configured using environment variables. Please find a table of
 
 | Name | Description | Default Value |
 | :--- | :--- | :--- |
-| `QUEUES` | **REQUIRED**: A `QUEUE_DELIMITER` separated list of work queues to monitor. | `predict,track` |
-| `QUEUE_DELIMITER` | A string used to separate a list of queue names in `QUEUES`. | `,` |
 | `RESOURCE_NAME` | **REQUIRED**: The name of the resource to scale. |  |
 | `RESOURCE_TYPE` | The resource type of `RESOURCE_NAME`, one of `deployment` or `job`. | `deployment` |
 | `RESOURCE_NAMESPACE` | The k8s namespace of `RESOURCE_NAME`. | `default` |
+| `QUEUES` | A `QUEUE_DELIMITER` separated list of work queues to monitor. | `predict,track` |
+| `QUEUE_DELIMITER` | A string used to separate a list of queue names in `QUEUES`. | `,` |
 | `INTERVAL` | How frequently the autoscaler checks for required resources, in seconds. | `5` |
 | `REDIS_HOST` | The IP address or hostname of Redis. | `redis-master` |
 | `REDIS_PORT` | The port used to connect to Redis. | `6379` |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Autoscaler is configured using environment variables. Please find a table of
 | :--- | :--- | :--- |
 | `RESOURCE_NAME` | **REQUIRED**: The name of the resource to scale. |  |
 | `RESOURCE_TYPE` | The resource type of `RESOURCE_NAME`, one of `deployment` or `job`. | `deployment` |
-| `RESOURCE_NAMESPACE` | The k8s namespace of `RESOURCE_NAME`. | `default` |
+| `RESOURCE_NAMESPACE` | The Kubernetes namespace of `RESOURCE_NAME`. | `default` |
 | `QUEUES` | A `QUEUE_DELIMITER` separated list of work queues to monitor. | `predict,track` |
 | `QUEUE_DELIMITER` | A string used to separate a list of queue names in `QUEUES`. | `,` |
 | `INTERVAL` | How frequently the autoscaler checks for required resources, in seconds. | `5` |

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -272,6 +272,10 @@ class Autoscaler(object):
 
     def scale_resource(self, desired_pods, current_pods,
                        resource_type, namespace, name):
+
+        if resource_type not in self.managed_resource_types:
+            raise ValueError('Cannot scale resource type: %s' % resource_type)
+
         if desired_pods == current_pods:
             return  # no scaling action is required
 
@@ -280,7 +284,7 @@ class Autoscaler(object):
             body = {'spec': {'parallelism': desired_pods}}
             res = self.patch_namespaced_job(name, namespace, body)
 
-        elif resource_type == 'deployment':
+        if resource_type == 'deployment':
             body = {'spec': {'replicas': desired_pods}}
             res = self.patch_namespaced_deployment(name, namespace, body)
 

--- a/autoscaler/autoscaler.py
+++ b/autoscaler/autoscaler.py
@@ -46,16 +46,8 @@ class Autoscaler(object):
 
     def __init__(self,
                  redis_client,
-                 scaling_config,
                  queues='predict',
-                 queue_delim=',',
-                 deployment_delim=';',
-                 param_delim='|'):
-
-        if deployment_delim == param_delim:
-            raise ValueError('`deployment_delim` and `param_delim` must be '
-                             'different. Got "{}" and "{}".'.format(
-                                 deployment_delim, param_delim))
+                 queue_delim=','):
 
         self.redis_keys = {q: 0 for q in queues.split(queue_delim)}
 
@@ -63,51 +55,7 @@ class Autoscaler(object):
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.completed_statuses = {'done', 'failed'}
 
-        self.autoscaling_params = self._get_autoscaling_params(
-            scaling_config=scaling_config.rstrip(),
-            deployment_delim=deployment_delim,
-            param_delim=param_delim)
-
         self.managed_resource_types = {'deployment', 'job'}
-
-        self.reference_pods = {}
-
-    def _get_autoscaling_params(self,
-                                scaling_config,
-                                deployment_delim=';',
-                                param_delim='|'):
-        raw_params = [x.split(param_delim)
-                      for x in scaling_config.split(deployment_delim)]
-
-        params = {}
-        for entry in raw_params:
-            try:
-                namespace_resource_type_name = (
-                    str(entry[3]).strip(),
-                    str(entry[4]).strip(),
-                    str(entry[6]).strip(),
-                )
-
-                if namespace_resource_type_name not in params:
-                    params[namespace_resource_type_name] = []
-
-                prefix = str(entry[5]).strip()
-
-                params[namespace_resource_type_name].append({
-                    'min_pods': int(entry[0]),
-                    'max_pods': int(entry[1]),
-                    'keys_per_pod': int(entry[2]),
-                    'prefix': prefix,
-                })
-
-                if prefix not in self.redis_keys:
-                    self.redis_keys[prefix] = 0
-
-            except (IndexError, ValueError):
-                self.logger.error('Autoscaling entry %s is malformed.', entry)
-                continue
-
-        return params
 
     def tally_queues(self):
         """Update counts of all redis queues"""
@@ -120,7 +68,7 @@ class Autoscaler(object):
 
             processing_q = 'processing-{}:*'.format(q)
             scan = self.redis_client.scan_iter(match=processing_q, count=1000)
-            num_in_progress = len([x for x in scan])
+            num_in_progress = len([x for x in scan])  # pylint: disable=R1721
 
             self.redis_keys[q] = num_items + num_in_progress
 
@@ -293,64 +241,33 @@ class Autoscaler(object):
                          namespace, current_pods, desired_pods)
         return True
 
-    def scale_resources(self):
-        """Scale each resource defined in `autoscaling_params`"""
-        self.logger.debug('Scaling primary resources.')
-        for fingerprint, entries in self.autoscaling_params.items():
-            # iterate through all entries with this fingerprint
-            namespace, resource_type, name = fingerprint
+    def scale(self, namespace, resource_type, name,
+              min_pods=0, max_pods=1, keys_per_pod=1):
 
-            self.logger.debug('Scaling %s `%s.%s` with %s config entries.',
-                              resource_type, namespace, name, len(entries))
-
-            # Sum up the current and desired pods over all entries
-            current_pods = self.get_current_pods(namespace, resource_type, name)
-            desired_pods = 0
-
-            min_pods_for_all_entries = []
-            max_pods_for_all_entries = []
-
-            if entries == []:  # this is the most conservative bound
-                self.logger.warning('%s `%s.%s` has no autoscaling entry.',
-                                    str(resource_type).capitalize(),
-                                    namespace, name)
-                continue
-
-            for entry in entries:
-                min_pods = entry['min_pods']
-                max_pods = entry['max_pods']
-                keys_per_pod = entry['keys_per_pod']
-                prefix = entry['prefix']
-
-                min_pods_for_all_entries.append(min_pods)
-                max_pods_for_all_entries.append(max_pods)
-
-                desired_pods += self.get_desired_pods(prefix, keys_per_pod,
-                                                      min_pods, max_pods,
-                                                      current_pods)
-
-            min_pods = max(min_pods_for_all_entries)
-            max_pods = min(max_pods_for_all_entries)
-
-            desired_pods = self.clip_pod_count(desired_pods, min_pods,
-                                               max_pods, current_pods)
-
-            if desired_pods > 0 and resource_type != 'job':
-                desired_pods = current_pods if current_pods > 0 else 1
-
-            self.logger.debug('%s `%s` in namespace `%s` has a current state '
-                              'of %s pods and a desired state of %s pods.',
-                              str(resource_type).capitalize(), name,
-                              namespace, current_pods, desired_pods)
-
-            try:
-                self.scale_resource(desired_pods, current_pods,
-                                    resource_type, namespace, name)
-            except kubernetes.client.rest.ApiException as err:
-                self.logger.warning('Failed to scale %s `%s.%s` due to %s: %s',
-                                    resource_type, namespace, name,
-                                    type(err).__name__, err)
-
-    def scale(self):
         self.tally_queues()
-        self.scale_resources()
+
+        self.logger.debug('Scaling %s `%s.%s`.',
+                          resource_type, namespace, name)
+
+        current_pods = self.get_current_pods(namespace, resource_type, name)
+
+        desired_pods = 0
+        for key in self.redis_keys:
+            desired_pods += self.get_desired_pods(key, keys_per_pod, min_pods,
+                                                  max_pods, current_pods)
+
+        desired_pods = self.clip_pod_count(desired_pods, min_pods,
+                                           max_pods, current_pods)
+
+        self.logger.debug('%s `%s` in namespace `%s` has a current state '
+                          'of %s pods and a desired state of %s pods.',
+                          str(resource_type).capitalize(), name,
+                          namespace, current_pods, desired_pods)
+
+        try:
+            self.scale_resource(desired_pods, current_pods,
+                                resource_type, namespace, name)
+        except kubernetes.client.rest.ApiException as err:
+            self.logger.warning('Failed to scale %s `%s.%s` due to %s: %s',
+                                resource_type, namespace, name,
+                                type(err).__name__, err)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 # Configuration of py.test
 [pytest]
+markers=
+    pep8
+
 addopts=-v
         --durations=20
 

--- a/scale.py
+++ b/scale.py
@@ -77,15 +77,27 @@ if __name__ == '__main__':
 
     SCALER = autoscaler.Autoscaler(
         redis_client=REDIS_CLIENT,
-        scaling_config=decouple.config('AUTOSCALING'),
-        queues=decouple.config('QUEUES', 'predict,track', cast=str),
+        queues=decouple.config('QUEUES', default='predict,track', cast=str),
         queue_delim=decouple.config('QUEUE_DELIMITER', ',', cast=str))
 
     INTERVAL = decouple.config('INTERVAL', default=5, cast=int)
 
+    RESOURCE_NAMESPACE = decouple.config('RESOURCE_NAMESPACE', default='default')
+    RESOURCE_TYPE = decouple.config('RESOURCE_TYPE', default='deployment')
+    RESOURCE_NAME = decouple.config('RESOURCE_TYPE')
+
+    MIN_PODS = decouple.config('MIN_PODS', default=0, cast=int)
+    MAX_PODS = decouple.config('MAX_PODS', default=1, cast=int)
+    KEYS_PER_POD = decouple.config('KEYS_PER_POD', default=1, cast=int)
+
     while True:
         try:
-            SCALER.scale()
+            SCALER.scale(namespace=RESOURCE_NAMESPACE,
+                         resource_type=RESOURCE_TYPE,
+                         name=RESOURCE_NAME,
+                         min_pods=MIN_PODS,
+                         max_pods=MAX_PODS,
+                         keys_per_pod=KEYS_PER_POD)
             time.sleep(INTERVAL)
         except Exception as err:  # pylint: disable=broad-except
             _logger.critical('Fatal Error: %s: %s', type(err).__name__, err)

--- a/scale.py
+++ b/scale.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
 
     RESOURCE_NAMESPACE = decouple.config('RESOURCE_NAMESPACE', default='default')
     RESOURCE_TYPE = decouple.config('RESOURCE_TYPE', default='deployment')
-    RESOURCE_NAME = decouple.config('RESOURCE_TYPE')
+    RESOURCE_NAME = decouple.config('RESOURCE_NAME')
 
     MIN_PODS = decouple.config('MIN_PODS', default=0, cast=int)
     MAX_PODS = decouple.config('MAX_PODS', default=1, cast=int)


### PR DESCRIPTION
The `AUTOSCALING` environment variable is difficult to configure, but it does enable complex autoscaling configurations, with many queues scaling 1 resource or different resources.

In the name of ease-of-use, I propose changing the autoscaler to only scale a single resource, but from many queues.  This enables new users to add queues to the `tf-serving` autoscaler by easily adding another item to the `QUEUES` environment variable.

However, this change will require users to deploy another autoscaler instance if they want to scale another resource (e.g. `tf-serving` has its autoscaler, and `training` would have another).

I believe that a smaller and simpler autoscaler will be much easier to configure, even if it will eventually require adding more helmfiles to the deployment for new resources.

Now, each row of the `AUTOSCALING` configuration has its own environment variable:
`RESOURCE_NAME`, `RESOURCE_TYPE`, and `RESOURCE_NAMESPACE`, along with `MAX_PODS`, `MIN_PODS`, and `KEYS_PER_POD`.  These allow the user to configure the scaling for each resource with well-named values, rather than a long string separated by `|` and `;`.

---

Fixes #30.