### PR TITLE
Upgrade kubernetes API to 18.x.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-kubernetes>=17.17.0,<18
+kubernetes~=18.20.0
 python-decouple>=3.1,<4
 redis>=3.4.1,<4


### PR DESCRIPTION
Support for Python 3.5 is dropped.