### PR TITLE
 Update kubernetes client to 20.x.y.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-kubernetes~=18.20.0
+kubernetes~=20.13.0
 python-decouple>=3.1,<4
-redis>=3.4.1,<4
+redis~=3.5.3


### PR DESCRIPTION
Compatibility with kubernetes 19, 20, and 21. GKE uses kubernetes 20 in the stable channel.

Additionally, update redis to last 3.x release.

Drops support for Python 2.7.